### PR TITLE
Create module.goalioforgotpassword-doctrine-orm.global.php.dist

### DIFF
--- a/config/module.goalioforgotpassword-doctrine-orm.global.php.dist
+++ b/config/module.goalioforgotpassword-doctrine-orm.global.php.dist
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Define the service manager alias for the doctrine entity manager that goalioforgotpassword needs
+ * because DoctrineModule does not seem to support the use of aliased service names.
+ * 
+ * @link https://github.com/doctrine/DoctrineModule/issues/246
+ * @link https://github.com/goalio/GoalioForgotPasswordDoctrineORM/issues/5
+ */
+return array(
+    'service_manager' => array(
+        'aliases' => array(
+            'goalioforgotpassword_doctrine_em' => 'Doctrine\ORM\EntityManager',
+        )
+    )
+);


### PR DESCRIPTION
To address issue #5: An alias "goalioforgotpassword_doctrine_em" was requested but no service could be found
